### PR TITLE
PS-2937 Build `docker-python-databricks` and `docker-python-mlflow`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,51 +6,82 @@ variables:
     value: ${{ replace(variables['Build.SourceBranch'],'refs/tags/','') }}
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'],'refs/tags/') }}
-  - name: dockerRegistryServiceConnection
-    value: '85ab7e7c-62ce-49e0-b201-bf56e6f3949e'
-  - name: imageRepository
-    value: 'docker-custom-python'
+  - name: azureContainerRegistryConnection
+    value: Keboola ACR
+  - name: azureContainerRegistry
+    value: keboola.azurecr.io
+  - name: imageRepository_base
+    value: docker-custom-python
+  - name: imageRepository_mlflow
+    value: docker-python-mlflow
+  - name: imageRepository_databricks
+    value: docker-python-databricks
 
 trigger:
   - refs/tags/*
 
 steps:
   - script: docker info
-    displayName: 'Info'
+    displayName: Info
 
   - script: echo '##vso[task.setvariable variable=imageTag]$(Build.BuildId)'
-    displayName: "Set the imageTag to buildId if it's not a tag build"
+    displayName: Set the imageTag to buildId if it's not a tag build
     condition: eq(variables['isTagBuild'], 'false')
 
+  - script: docker build -t docker-custom-python .
+    displayName: Build Docker image
+
   - task: Docker@2
+    displayName: Login to ACR
     inputs:
-      containerRegistry: 'keboola-4338'
-      repository: 'docker-custom-python'
-      command: 'build'
-      Dockerfile: '**/Dockerfile'
-      tags: |
-        latest
-        $(imageTag)
+      command: login
+      containerRegistry: $(azureContainerRegistryConnection)
+    condition: eq(variables['isTagBuild'], 'true')
+
+# Push base image
+  - script: |
+      set -Eeuo pipefail
+      docker login -u="$(QUAY_USERNAME)" -p="$(QUAY_PASSWORD)" quay.io
+      docker tag docker-custom-python quay.io/keboola/$(imageRepository_base):$(imageTag)
+      docker tag docker-custom-python quay.io/keboola/$(imageRepository_base):latest
+      docker push -a quay.io/keboola/$(imageRepository_base)
+    condition: eq(variables['isTagBuild'], 'true')
+    displayName: Push $(imageRepository_base) to quay.io
 
   - script: |
-      docker login -u="$(QUAY_USERNAME)" -p="$(QUAY_PASSWORD)" quay.io
-      docker tag keboola.azurecr.io/docker-custom-python quay.io/$(KBC_APP_REPOSITORY):$(imageTag)
-      docker tag keboola.azurecr.io/docker-custom-python quay.io/$(KBC_APP_REPOSITORY):latest
-      docker images
-      docker push quay.io/$(KBC_APP_REPOSITORY):$(imageTag)
-      docker push quay.io/$(KBC_APP_REPOSITORY):latest
+      set -Eeuo pipefail
+      docker tag docker-custom-python $(azureContainerRegistry)/$(imageRepository_base):$(imageTag)
+      docker push -a $(azureContainerRegistry)/$(imageRepository_base)
+    displayName: Push $(imageRepository_base) to ACR
     condition: eq(variables['isTagBuild'], 'true')
-    displayName: 'Push latest to quay.io'
 
-  - task: Docker@2
+# Push MLFlow
+  - task: ECRPushImage@1
     inputs:
-      containerRegistry: 'keboola-4338'
-      repository: 'docker-custom-python'
-      command: 'push'
-      tags: '$(imageTag)'
+      awsCredentials: Production - ECR Distribution - MLFlow
+      regionName: us-east-1
+      repositoryName: keboola/$(imageRepository_mlflow)
+      sourceImageName: docker-custom-python
+      pushTag: $(imageTag)
+    displayName: Push $(imageRepository_mlflow) to ECR
     condition: eq(variables['isTagBuild'], 'true')
-    displayName: 'Push latest to ACR'
 
+  - script: |
+      set -Eeuo pipefail
+      docker tag docker-custom-python $(azureContainerRegistry)/$(imageRepository_mlflow):$(imageTag)
+      docker push -a $(azureContainerRegistry)/$(imageRepository_mlflow)
+    displayName: Push $(imageRepository_mlflow) to ACR
+    condition: eq(variables['isTagBuild'], 'true')
+
+# Push Databricks
+  - script: |
+      set -Eeuo pipefail
+      docker tag docker-custom-python $(azureContainerRegistry)/$(imageRepository_databricks):$(imageTag)
+      docker push -a $(azureContainerRegistry)/$(imageRepository_databricks)
+    displayName: Push $(imageRepository_databricks) to ACR
+    condition: eq(variables['isTagBuild'], 'true')
+
+# Publish the latest tag info
   - script: printf "%s" "$(imageTag)" > base-python-artifact
     condition: eq(variables['isTagBuild'], 'true')
     displayName: Create artifact


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2937

Integrace `docker-python-mlflow` a `docker-python-databricks`. Images nemely navic nic, co by nebylo v base image. Zaroven je ale nejakou dobu chceme zachovat kvuli zpetne kompatibilite.

Pipeline otestovana pres custom tag: https://dev.azure.com/keboola-dev/Data%20Science/_build/results?buildId=16685&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9