### PR TITLE
PS-3808 Snowpark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,8 @@ RUN pip3 install --no-cache-dir --upgrade --force-reinstall git+https://github.c
     && pip3 install --no-cache-dir --upgrade --force-reinstall \
         git+https://github.com/keboola/sapi-python-client.git@0.4.0 \
         keboola.component \
+        cryptography\<37 \
         chardet\<4 \
-        cryptography\<4 \
     && mkdir -p /root/.cache/snowflake/ \
 	&& chown :users -R /home/default \
 	&& chmod a+rwx -R /home/default

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ RUN mkdir /home/default \
         seaborn \
         simpleeval \
         snowflake-connector-python[pandas] \
+        snowflake-snowpark-python \
         sqlalchemy\
         statsmodels \
         sympy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,10 +113,10 @@ RUN mkdir /home/default \
 	&& chown :users -R /home/default \
 	&& chmod a+rwx -R /home/default
 
-RUN pip3 install --no-cache-dir --upgrade --force-reinstall git+git://github.com/keboola/python-docker-application.git@2.2.0 \
+RUN pip3 install --no-cache-dir --upgrade --force-reinstall git+https://github.com/keboola/python-docker-application.git@2.2.0 \
     && pip3 install --no-cache-dir --find-links https://h2o-release.s3.amazonaws.com/h2o/latest_stable_Py.html h2o \
     && pip3 install --no-cache-dir --upgrade --force-reinstall \
-        git+git://github.com/keboola/sapi-python-client.git@0.4.0 \
+        git+https://github.com/keboola/sapi-python-client.git@0.4.0 \
         keboola.component \
         chardet\<4 \
         cryptography\<4 \

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Keboola :(){:|:&};: s.r.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Keboola Docker Custom Python
 Base image for Python components. See [documentation](https://developers.keboola.com/extend/) for more details about building components for KBC.
+
+## License
+
+MIT licensed, see [LICENSE](./LICENSE) file.


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3808

Snowpark vyzaduje Python 3.8. Zalozil jsem proto branch `python-3.8`, ktera by mela slouzit jako main pro dalsi releasy Python 3.8 image.

Navrhoval bych zaroven zmenit schema tagu z `3.1.0` na `python-3.8-1` (a dal `python-3.8-2` atd.) a z `5.0.0` na `python-3.10-1`. Je to bez semver, ale tady fakt nevidim duvod se ho drzet. Release smerem k userum resime pres UI/runtimes API. 