### PR TITLE
Lock PyYAML version, fixes the problem with new Cython

### DIFF
--- a/python-3.10/Dockerfile
+++ b/python-3.10/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir $VIRTUAL_ENV \
         pytest \
 	    python-box \
         python-dotenv \
-        PyYaml \
+        'PyYaml==5.3.1' \
         qgrid \
         scikit-image \
         scikit-learn \


### PR DESCRIPTION
S timhle se mi podarilo konecne zbuildit image pro Python 3.10. Vlastne je to unrelated, k otmu, co je cilem (update snowparku, https://keboola.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/99/SUPPORT-180), ale kdyz se nezbuildi vsechny images, nedojede pipeline.