### PR TITLE
[AJDA-2404] Archive repository - replaced by keboola/runtime-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Keboola Docker Custom Python
-Base image for Python components. See [documentation](https://developers.keboola.com/extend/) for more details about building components for KBC.
 
-## License
-
-MIT licensed, see [LICENSE](./LICENSE) file.
+> **This repository has been archived.**
+> It has been replaced by [keboola/runtime-images](https://github.com/keboola/runtime-images).

--- a/python-3.10/Dockerfile
+++ b/python-3.10/Dockerfile
@@ -113,7 +113,7 @@ RUN mkdir $VIRTUAL_ENV \
     && pip3 install --no-cache-dir --find-links https://h2o-release.s3.amazonaws.com/h2o/latest_stable_Py.html h2o \
     && pip3 install --no-cache-dir --upgrade --force-reinstall \
         git+https://github.com/keboola/sapi-python-client.git@0.4.0 \
-        keboola.component \
+        'keboola.component<1.9.0' \
         'cffi<2.0.0' \
         charset-normalizer\<3 \
         cryptography\<41 \


### PR DESCRIPTION
Update README to reflect that this repository has been archived and replaced by [keboola/runtime-images](https://github.com/keboola/runtime-images).